### PR TITLE
Move `@types` dependencies to production dependencies

### DIFF
--- a/renovate-shared.json
+++ b/renovate-shared.json
@@ -10,14 +10,19 @@
       "matchPackagePatterns": ["*"]
     },
     {
-      "groupName": "Production Dependencies",
+      "groupName": "npm development + production Dependencies",
       "matchPackagePatterns": ["*"],
-      "matchDepTypes": ["dependencies"]
+      "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
-      "groupName": "Development Dependencies",
+      "groupName": "TypeScript development Dependencies",
       "matchPackagePatterns": ["*"],
-      "matchDepTypes": ["pre-commit", "devDependencies"]
+      "matchPackageNames": ["/.*eslint.*/i", "typescript", "prettier", "ts-auto-mock"]
+    },
+    {
+      "groupName": "pre-commit Dependencies",
+      "matchPackagePatterns": ["*"],
+      "matchDepTypes": ["pre-commit"]
     }
   ],
   "pre-commit": {

--- a/renovate-shared.json
+++ b/renovate-shared.json
@@ -17,7 +17,7 @@
     {
       "groupName": "Development Dependencies",
       "matchPackagePatterns": ["*"],
-      "matchDepTypes": ["devDependencies", "pre-commit"],
+      "matchDepTypes": ["pre-commit", "devDependencies"],
       "matchPackageNames": ["!/^@types.*/"]
     }
   ],

--- a/renovate-shared.json
+++ b/renovate-shared.json
@@ -10,20 +10,15 @@
       "matchPackagePatterns": ["*"]
     },
     {
-      "groupName": "npm development + production Dependencies",
+      "groupName": "Production Dependencies",
       "matchPackagePatterns": ["*"],
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
-      "groupName": "TypeScript development Dependencies",
+      "groupName": "Development Dependencies",
       "matchPackagePatterns": ["*"],
       "matchPackageNames": ["!/^@types.*/"],
-      "matchDepTypes": ["devDependencies"]
-    },
-    {
-      "groupName": "pre-commit Dependencies",
-      "matchPackagePatterns": ["*"],
-      "matchDepTypes": ["pre-commit"]
+      "matchDepTypes": ["devDependencies", "pre-commit"]
     }
   ],
   "pre-commit": {

--- a/renovate-shared.json
+++ b/renovate-shared.json
@@ -17,8 +17,8 @@
     {
       "groupName": "Development Dependencies",
       "matchPackagePatterns": ["*"],
-      "matchPackageNames": ["!/^@types.*/"],
-      "matchDepTypes": ["devDependencies", "pre-commit"]
+      "matchDepTypes": ["devDependencies", "pre-commit"],
+      "matchPackageNames": ["!/^@types.*/"]
     }
   ],
   "pre-commit": {

--- a/renovate-shared.json
+++ b/renovate-shared.json
@@ -17,7 +17,8 @@
     {
       "groupName": "TypeScript development Dependencies",
       "matchPackagePatterns": ["*"],
-      "matchPackageNames": ["/.*eslint.*/i", "typescript", "prettier", "ts-auto-mock"]
+      "matchPackageNames": ["!/^@types.*/"],
+      "matchDepTypes": ["devDependencies"]
     },
     {
       "groupName": "pre-commit Dependencies",


### PR DESCRIPTION
We want to include production and development dependencies in one group, except when they relate to typescript. This is because most dev dependencies are for type definitions that have to be considered at the same time as their associated production dependency.